### PR TITLE
Update testcontainers version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <junit.version>5.5.2</junit.version>
-        <testcontainers.version>1.12.3</testcontainers.version>
+        <testcontainers.version>1.18.3</testcontainers.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/dasniko/smtp/SmtpTest.java
+++ b/src/test/java/dasniko/smtp/SmtpTest.java
@@ -28,13 +28,13 @@ public class SmtpTest {
 
     @Container
     public static GenericContainer<?> mailhog = new GenericContainer<>("mailhog/mailhog")
-        .withExposedPorts(PORT_SMTP, PORT_HTTP)
-        .waitingFor(Wait.forHttp("/"));
+        .withExposedPorts(PORT_HTTP, PORT_SMTP)
+        .waitingFor(Wait.forHttp("/").forPort(PORT_HTTP));
 
     @BeforeEach
     public void setUp() {
         smtpPort = mailhog.getMappedPort(PORT_SMTP);
-        smtpHost = mailhog.getContainerIpAddress();
+        smtpHost = mailhog.getHost();
         Integer httpPort = mailhog.getMappedPort(PORT_HTTP);
 
         RestAssured.baseURI = "http://" + smtpHost;


### PR DESCRIPTION
While testing this repository, I found that the tests don't work anymore because the Testcontainers version was several versions behind. The tests didn't execute as needed because the required Ryuk images are no longer available.


Therefore, I updated Testcontainers to a version that functions correctly and altered the test to accommodate the changes made to its API.


I stumbled upon your repo while searching for an example of testing with Mailhog, and I found it quite useful. Though pretty simple, I felt it would be beneficial to maintain its operational state, making it easier for future users.